### PR TITLE
Put it to compile under 5.10 kernel version

### DIFF
--- a/fl2000_gem.c
+++ b/fl2000_gem.c
@@ -125,7 +125,7 @@ static struct fl2000_gem_object *fl2000_gem_create_with_handle(struct drm_file *
 	ret = drm_gem_handle_create(file_priv, gem_obj, handle);
 
 	/* drop reference from allocate - handle holds it now. */
-	drm_gem_object_put_unlocked(gem_obj);
+	drm_gem_object_put(gem_obj);
 
 	if (ret)
 		return ERR_PTR(ret);
@@ -201,7 +201,7 @@ struct sg_table *fl2000_gem_prime_get_sg_table(struct drm_gem_object *gem_obj)
 	if (!obj->pages)
 		return ERR_PTR(-ENOMEM);
 
-	return drm_prime_pages_to_sg(obj->pages, obj->num_pages);
+	return drm_prime_pages_to_sg(obj->base.dev, obj->pages, obj->num_pages);
 }
 
 struct drm_gem_object *fl2000_gem_prime_import_sg_table(struct drm_device *drm,


### PR DESCRIPTION
All the alterations cited here happened between 5.8 and 5.10 kernel
versions.

drm_dev_init() is not a "public" function anymore, so drm_dev_alloc() or
devm_drm_dev_alloc() must be used instead. And they use a different form
of initialization, so a lot of things have moved around or had just been
cutted off.

Why devm_drm_dev_alloc()? It was the most popular in drivers/gpu/drm
drivers.

drm_gem_object_put() is the replacement to the _unlocked() sufixed
option. The latter took care of locks, and that, as far as I understood,
is not need anymore.

drm_prime_pages_to_sg() changed it's signature. Now it needs a pointer
to the device struct as it's first argument. Luckly, the drm_gem_object
struct carries a pointer to it ;)