### PR TITLE
Add missing include of <linux/vmalloc.h>

### DIFF
--- a/fl2000.h
+++ b/fl2000.h
@@ -18,6 +18,7 @@
 #include <linux/i2c.h>
 #include <linux/component.h>
 #include <linux/regmap.h>
+#include <linux/vmalloc.h>
 #include <linux/dma-buf.h>
 #include <linux/dma-mapping.h>
 #include <linux/time.h>


### PR DESCRIPTION
This header is needed for the symbols vunmap, vmap, and VM_MAP, used
in fl2000_streaming.c.