### PR TITLE
Fix start of the checkpatch script

### DIFF
--- a/scripts/checkpatch.sh
+++ b/scripts/checkpatch.sh
@@ -18,7 +18,7 @@ do
 	if [[ $file == *.mod.c ]]; then
 		continue
 	fi
-	./checkpatch.pl --strict --no-summary --no-tree "$@" -f "$file"
+	perl checkpatch.pl --strict --no-summary --no-tree "$@" -f "$file"
 	status=$status+$?
 done
 


### PR DESCRIPTION
Use Perl instead of making script executable which was anyway missed in the original script