### PR TITLE
Fix build on Linux 6.12+ kernel

### DIFF
--- a/bridge/it66121_drv.c
+++ b/bridge/it66121_drv.c
@@ -842,7 +842,7 @@ static void __exit it66121_remove(void)
 
 	component_del(&priv->client->dev, &it66121_component_ops);
 
-	kfree(priv->edid);
+	drm_edid_free(priv->edid);
 
 	drm_bridge_remove(&priv->bridge);
 

--- a/fl2000.h
+++ b/fl2000.h
@@ -30,15 +30,14 @@
 #include <drm/drm_fourcc.h>
 #include <drm/drm_fb_helper.h>
 #include <drm/drm_framebuffer.h>
-#include <drm/drm_fbdev_generic.h>
+#include <drm/drm_fbdev_shmem.h>
 #include <drm/drm_gem_framebuffer_helper.h>
-#include <drm/drm_gem_dma_helper.h>
+#include <drm/drm_gem_shmem_helper.h>
 #include <drm/drm_atomic_helper.h>
 #include <drm/drm_simple_kms_helper.h>
 #include <drm/drm_crtc_helper.h>
 #include <drm/drm_probe_helper.h>
 #include <drm/drm_damage_helper.h>
-#include <drm/drm_fb_dma_helper.h>
 
 #include "fl2000_registers.h"
 


### PR DESCRIPTION
- Replace drm_fbdev_generic.h with drm_fbdev_shmem.h
- Replace drm_gem_dma_helper.h with drm_gem_shmem_helper.h
- Replace drm_fb_dma_helper.h (removed)
- Update drm_driver to use DRM_GEM_SHMEM_DRIVER_OPS
- Use DEFINE_DRM_GEM_FOPS instead of DEFINE_DRM_GEM_DMA_FOPS
- Replace drm_fbdev_generic_setup with drm_fbdev_shmem_setup
- Update it66121 bridge to use drm_edid_read_custom API
- Remove .lastclose callback (removed from drm_driver in 6.12+)

The DMA GEM helpers are not enabled in Debian's default kernel configuration, but SHMEM helpers are available. This also adapts to the renamed/removed DRM APIs in kernel 6.12+.

💘 Generated with Crush

Assisted-by: GLM-5 via Crush <crush@charm.land>